### PR TITLE
Allow CLI help without heavy dependencies

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+class BenchmarkCLITest(unittest.TestCase):
+    def test_help_succeeds_without_megadetector(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        env = os.environ.copy()
+        # Avoid picking up user site packages to simulate a minimal environment
+        env["PYTHONNOUSERSITE"] = "1"
+        # Ensure stdout/stderr are captured for assertions
+        result = subprocess.run(
+            [sys.executable, "-S", "benchmark.py", "--help"],
+            cwd=repo_root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"CLI help failed with stderr:\n{result.stderr}",
+        )
+        self.assertIn("MegaDetector CPU Benchmark", result.stdout)
+        self.assertNotIn("MegaDetector is required", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- guard benchmark optional imports so the CLI help works even when torch, numpy, cpuinfo, and psutil are unavailable
- update the regression test to invoke the help command with `python -S` to better simulate a dependency-light environment

## Testing
- python -S benchmark.py --help
- python -m unittest tests.test_cli

------
https://chatgpt.com/codex/tasks/task_e_68e405d3dc78832a9ecae8be93e1ea5c